### PR TITLE
webp crateを0.3.0に変更

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde = {version="^1.0.164",features=["derive"]}
 serde_json ="1"
 reqwest = { version = "0.11", default-features = false , features = ["stream","rustls-tls-webpki-roots"] }
 image = "0.25"
-webp = { version = "0.2.7", default-features = false }
+webp = { version = "0.3.0", default-features = false }
 resvg = {version="0.41",features = [ "text","memmap-fonts","raster-images" ] }
 rexif = "0.7.3"
 avif-decoder_dep = { path="./avif-decoder_dep" ,optional = true }


### PR DESCRIPTION
これによって2024-04-18T19:22:00Z頃からビルドが通らない問題を解消する
https://github.com/jaredforth/webp/issues/38