### PR TITLE
Fix: Unable to build on Ubuntu reason by 'unknown codegen option'

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,4 @@
 [env]
 SYSTEM_DEPS_BUILD_INTERNAL="always"
 [build]
-rustflags=["-C link-args=-Wl,-lc"]
+rustflags=["-C", "link-args=-Wl,-lc"]


### PR DESCRIPTION
#68 の解決策として提示している修正です。